### PR TITLE
Feature/fix saga inject multiple times

### DIFF
--- a/app/utils/injectSaga.js
+++ b/app/utils/injectSaga.js
@@ -28,23 +28,34 @@ export default ({ key, saga, mode, args }) => (WrappedComponent) => {
       store: PropTypes.object.isRequired,
     };
     static displayName = `withSaga(${(WrappedComponent.displayName || WrappedComponent.name || 'Component')})`;
+    state = {
+      isReady: false,
+    }
 
-    componentWillMount() {
+    componentDidMount() {
       const { injectSaga } = this.injectors;
       const injectedArgs = args || [this.props];
-
-      injectSaga(key, { saga, mode }, ...injectedArgs);
+      this.isComponentMounted = true;
+      injectSaga(key, { saga, mode }, ...injectedArgs).then(() => {
+        if (this.isComponentMounted) {
+          this.setState({ isReady: true });
+        }
+      });
     }
 
     componentWillUnmount() {
       const { ejectSaga } = this.injectors;
-
+      this.isComponentMounted = false;
       ejectSaga(key);
     }
 
     injectors = getInjectors(this.context.store);
+    isComponentMounted = false;
 
     render() {
+      if (!this.state.isReady) {
+        return null;
+      }
       return <WrappedComponent {...this.props} />;
     }
   }

--- a/app/utils/sagaInjectors.js
+++ b/app/utils/sagaInjectors.js
@@ -33,26 +33,29 @@ export function injectSagaFactory(store, isValid) {
   return function injectSaga(key, descriptor = {}, ...args) {
     if (!isValid) checkStore(store);
 
-    const newDescriptor = { ...descriptor, mode: descriptor.mode || RESTART_ON_REMOUNT };
-    const { saga, mode } = newDescriptor;
+    return new Promise((resolve) => {
+      const newDescriptor = { ...descriptor, mode: descriptor.mode || RESTART_ON_REMOUNT };
+      const { saga, mode } = newDescriptor;
 
-    checkKey(key);
-    checkDescriptor(newDescriptor);
+      checkKey(key);
+      checkDescriptor(newDescriptor);
 
-    let hasSaga = Reflect.has(store.injectedSagas, key);
+      let hasSaga = Reflect.has(store.injectedSagas, key);
 
-    if (process.env.NODE_ENV !== 'production') {
-      const oldDescriptor = store.injectedSagas[key];
-      // enable hot reloading of daemon and once-till-unmount sagas
-      if (hasSaga && oldDescriptor.saga !== saga) {
-        oldDescriptor.task.cancel();
-        hasSaga = false;
+      if (process.env.NODE_ENV !== 'production') {
+        const oldDescriptor = store.injectedSagas[key];
+        // enable hot reloading of daemon and once-till-unmount sagas
+        if (hasSaga && oldDescriptor.saga !== saga) {
+          oldDescriptor.task.cancel();
+          hasSaga = false;
+        }
       }
-    }
 
-    if (!hasSaga || (hasSaga && mode !== DAEMON && mode !== ONCE_TILL_UNMOUNT)) {
-      store.injectedSagas[key] = { ...newDescriptor, task: store.runSaga(saga, ...args) }; // eslint-disable-line no-param-reassign
-    }
+      if (!hasSaga || (hasSaga && mode !== DAEMON && mode !== ONCE_TILL_UNMOUNT)) {
+        store.injectedSagas[key] = { ...newDescriptor, task: store.runSaga(saga, ...args) }; // eslint-disable-line no-param-reassign
+      }
+      resolve();
+    });
   };
 }
 

--- a/app/utils/tests/injectSaga.test.js
+++ b/app/utils/tests/injectSaga.test.js
@@ -4,7 +4,7 @@
 
 import { memoryHistory } from 'react-router-dom';
 import { put } from 'redux-saga/effects';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 import configureStore from '../../configureStore';
@@ -30,7 +30,7 @@ describe('injectSaga decorator', () => {
   beforeEach(() => {
     store = configureStore({}, memoryHistory);
     injectors = {
-      injectSaga: jest.fn(),
+      injectSaga: jest.fn(() => new Promise((resolve) => resolve())),
       ejectSaga: jest.fn(),
     };
     ComponentWithSaga = injectSaga({ key: 'test', saga: testSaga, mode: 'testMode' })(Component);
@@ -43,6 +43,7 @@ describe('injectSaga decorator', () => {
 
     expect(injectors.injectSaga).toHaveBeenCalledTimes(1);
     expect(injectors.injectSaga).toHaveBeenCalledWith('test', { saga: testSaga, mode: 'testMode' }, props);
+    expect(injectors.injectSaga()).resolves.toEqual(undefined);
   });
 
   it('should inject given saga, mode, and user defined args', () => {
@@ -71,8 +72,9 @@ describe('injectSaga decorator', () => {
 
   it('should propagate props', () => {
     const props = { testProp: 'test' };
-    const renderedComponent = shallow(<ComponentWithSaga {...props} />, { context: { store } });
+    const renderedComponent = mount(<ComponentWithSaga {...props} />, { context: { store } });
 
+    renderedComponent.mount();
     expect(renderedComponent.prop('testProp')).toBe('test');
   });
 });

--- a/app/utils/tests/sagaInjectors.test.js
+++ b/app/utils/tests/sagaInjectors.test.js
@@ -130,7 +130,7 @@ describe('injectors', () => {
     it('should check a store if the second argument is falsy', () => {
       const inject = injectSagaFactory({});
 
-      expect(() => inject('test', testSaga)).toThrow();
+      expect(inject('test', testSaga)).rejects.toBeDefined();
     });
 
     it('it should not check a store if the second argument is true', () => {
@@ -140,18 +140,18 @@ describe('injectors', () => {
     });
 
     it('should validate saga\'s key', () => {
-      expect(() => injectSaga('', { saga: testSaga })).toThrow();
-      expect(() => injectSaga(1, { saga: testSaga })).toThrow();
+      expect(injectSaga('', { saga: testSaga })).rejects.toBeDefined();
+      expect(injectSaga(1, { saga: testSaga })).rejects.toBeDefined();
     });
 
     it('should validate saga\'s descriptor', () => {
-      expect(() => injectSaga('test')).toThrow();
-      expect(() => injectSaga('test', { saga: 1 })).toThrow();
-      expect(() => injectSaga('test', { saga: testSaga, mode: 'testMode' })).toThrow();
-      expect(() => injectSaga('test', { saga: testSaga, mode: 1 })).toThrow();
-      expect(() => injectSaga('test', { saga: testSaga, mode: RESTART_ON_REMOUNT })).not.toThrow();
-      expect(() => injectSaga('test', { saga: testSaga, mode: DAEMON })).not.toThrow();
-      expect(() => injectSaga('test', { saga: testSaga, mode: ONCE_TILL_UNMOUNT })).not.toThrow();
+      expect(injectSaga('test')).rejects.toBeDefined();
+      expect(injectSaga('test', { saga: 1 })).rejects.toBeDefined();
+      expect(injectSaga('test', { saga: testSaga, mode: 'testMode' })).rejects.toBeDefined();
+      expect(injectSaga('test', { saga: testSaga, mode: 1 })).rejects.toBeDefined();
+      expect(injectSaga('test', { saga: testSaga, mode: RESTART_ON_REMOUNT })).resolves.toEqual(undefined);
+      expect(injectSaga('test', { saga: testSaga, mode: DAEMON })).resolves.toEqual(undefined);
+      expect(injectSaga('test', { saga: testSaga, mode: ONCE_TILL_UNMOUNT })).resolves.toEqual(undefined);
     });
 
     it('should pass args to saga.run', () => {


### PR DESCRIPTION
According to the issue #2314, 
I use `componentDidMount` and `Promise` to get the saga ready,
then rendering child component

Cuz of React v16, `componentWillMount` is unsafe and we should not use it.
Second, `componentWillMount` has the render ordering problem ([comment](https://github.com/react-boilerplate/react-boilerplate/issues/2314#issuecomment-426911261))

Using this modification, we can assure that sagas have already injected when target component be rendered